### PR TITLE
Fixed typo in modules.rst

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,4 +1,4 @@
-Module documenation
+Module documentation
 ===================
 
 .. raw:: html


### PR DESCRIPTION
"documentation" is now correctly spelled